### PR TITLE
prepare for a rustc experiment: unsafe before_exec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,11 +563,16 @@ mod imp {
             // integers through `string_arg` above.
             let read = self.read.as_raw_fd();
             let write = self.write.as_raw_fd();
-            cmd.before_exec(move || {
-                set_cloexec(read, false)?;
-                set_cloexec(write, false)?;
-                Ok(())
-            });
+            #[allow(unused_unsafe)] // for a rustc experiment
+            unsafe {
+                // We are not exploiting `fork` to duplicate anything we shouldn't duplicate,
+                // so this `before_exec` is fine.
+                cmd.before_exec(move || {
+                    set_cloexec(read, false)?;
+                    set_cloexec(write, false)?;
+                    Ok(())
+                });
+            }
         }
     }
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/39575 for all the details.

I am not sure if this is what we usually do in such a case. Please let me know if I am doing it wrong.