### PR TITLE
Bump rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jobserver"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/jobserver-rs"
@@ -17,7 +17,7 @@ log = "0.4"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-rand = "0.4"
+rand = "0.6"
 
 [dev-dependencies]
 futures = "0.1"


### PR DESCRIPTION
added the support of multiple revisions so it is possible to select the version of rand to depend on e.g. if an old rustc shall be supported.

do not know if it is a good idea to do this as it gets harder to maintain this crate if something new from rand is used that is not part of the older revision.