### PR TITLE
Add support for non-unix and non-windows platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1047,3 +1047,10 @@ mod imp {
         }
     }
 }
+
+#[test]
+fn no_helper_deadlock() {
+    let x = crate::Client::new(32).unwrap();
+    let _y = x.clone();
+    std::mem::drop(x.into_helper_thread(|_| {}).unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,15 +255,14 @@ impl Client {
     /// variables for the child process, and on Unix this will also allow the
     /// two file descriptors for this client to be inherited to the child.
     ///
-    /// On platforms other than Unix and Windows this does nothing.
+    /// On platforms other than Unix and Windows this panics.
     pub fn configure(&self, cmd: &mut Command) {
-        if let Some(arg) = self.inner.string_arg() {
-            // Older implementations of make use `--jobserver-fds` and newer
-            // implementations use `--jobserver-auth`, pass both to try to catch
-            // both implementations.
-            let value = format!("--jobserver-fds={0} --jobserver-auth={0}", arg);
-            cmd.env("CARGO_MAKEFLAGS", &value);
-        }
+        let arg = self.inner.string_arg();
+        // Older implementations of make use `--jobserver-fds` and newer
+        // implementations use `--jobserver-auth`, pass both to try to catch
+        // both implementations.
+        let value = format!("--jobserver-fds={0} --jobserver-auth={0}", arg);
+        cmd.env("CARGO_MAKEFLAGS", &value);
         self.inner.configure(cmd);
     }
 
@@ -576,8 +575,8 @@ mod imp {
             }
         }
 
-        pub fn string_arg(&self) -> Option<String> {
-            Some(format!("{},{} -j", self.read.as_raw_fd(), self.write.as_raw_fd()))
+        pub fn string_arg(&self) -> String {
+            format!("{},{} -j", self.read.as_raw_fd(), self.write.as_raw_fd())
         }
 
         pub fn configure(&self, cmd: &mut Command) {
@@ -884,8 +883,8 @@ mod imp {
             }
         }
 
-        pub fn string_arg(&self) -> Option<String> {
-            Some(self.name.clone())
+        pub fn string_arg(&self) -> String {
+            self.name.clone()
         }
 
         pub fn configure(&self, _cmd: &mut Command) {
@@ -1009,11 +1008,16 @@ mod imp {
             Ok(())
         }
 
-        pub fn string_arg(&self) -> Option<String> {
-            None
+        pub fn string_arg(&self) -> String {
+            panic!(
+                "On this platform there is no cross process jobserver support,
+                 so Client::configure is not supported."
+            );
         }
 
-        pub fn configure(&self, _cmd: &mut Command) {}
+        pub fn configure(&self, _cmd: &mut Command) {
+            unreachable!();
+        }
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
Cross process jobserver and thread cancellation is not supported

This is part of an experiment to port rustc to wasi. (cc https://github.com/rust-lang/miri/issues/722)

cc @RReverser