### PR TITLE
Support for unique token values

### DIFF
--- a/examples/shared_resources.rs
+++ b/examples/shared_resources.rs
@@ -1,0 +1,69 @@
+//! The jobserver can also be used as a synchronisation primitive for shared
+//! resources.
+//!
+//! By populating the jobserver with unique tokens, we can provide a reference
+//! to a single instance of a shared resource.
+extern crate jobserver;
+
+#[cfg(unix)]
+pub mod imp {
+    use std::sync::mpsc::channel;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time;
+
+    use jobserver::Client;
+
+    fn sleep() {
+        thread::sleep(time::Duration::from_millis(500));
+    }
+
+    /// Run some number of jobs in parallel, limited by the number of tokens.
+    fn do_jobs_with_tokens(jobs: usize, tokens: u8) {
+        println!("");
+        println!("Running {} jobs with {} resources:", jobs, tokens);
+        let now = time::Instant::now();
+
+        let jobserver =
+            Arc::new(Client::new_with_unique(tokens).expect("Couldn't create jobserver."));
+
+        // Spawn jobs in new threads, but limit by acquiring tokens.
+        let (tx, rx) = channel();
+        for job_number in 0..jobs {
+            let (jobserver, tx) = (Arc::clone(&jobserver), tx.clone());
+            thread::spawn(move || {
+                let token = jobserver.acquire().expect("Couldn't acquire token.");
+                println!(
+                    "Job {} is using resource {}.",
+                    job_number,
+                    token.data().byte()
+                );
+                sleep();
+                tx.send(()).unwrap();
+            });
+        }
+
+        // Collect jobs
+        for _ in 0..jobs {
+            rx.recv().unwrap();
+        }
+        println!("Execution took: {}ms", now.elapsed().as_millis());
+    }
+
+    pub fn run() {
+        do_jobs_with_tokens(6, 1);
+        do_jobs_with_tokens(6, 2);
+        do_jobs_with_tokens(6, 6);
+    }
+}
+
+#[cfg(not(unix))]
+pub mod imp {
+    pub fn run() {
+        println!("This example is only supported on unix platforms.");
+    }
+}
+
+fn main() {
+    imp::run();
+}


### PR DESCRIPTION
This PR adds the ability to create a jobserver with known, unique token values with `Client::new_with_unique`, and read those values with `token.data().byte()`.

---

Our use case is synchronising shared resources between multiple tests in our codebase. We create a fifo and populate it with tokens of known value (the bytes `0` to `n`). Each tests must acquire a token before accessing a shared resource - the value of the token then acts as a reference to the resource to use during the test.

For instance, while running tests in parallel, we have `n` test databases set up, but only one test may read/write data at any point.

This allows us to run tests in parallel across multiple threads/languages, independent of any one particular test framework.

---

We've been using this for a while now and it's working well - is this something you're interested in adding to the library? It's not strictly compatible with the `GNU make spec` which states:

> - All tokens are identical.

However, in practice the value of the token is not used anywhere and treated as opaque by all other consumers.
