### PR TITLE
Set the -j flag in make flags on all platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,7 @@ impl Client {
         // Older implementations of make use `--jobserver-fds` and newer
         // implementations use `--jobserver-auth`, pass both to try to catch
         // both implementations.
-        let value = format!("--jobserver-fds={0} --jobserver-auth={0}", arg);
+        let value = format!("-j --jobserver-fds={0} --jobserver-auth={0}", arg);
         cmd.env("CARGO_MAKEFLAGS", &value);
         self.inner.configure(cmd);
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -184,7 +184,7 @@ impl Client {
     }
 
     pub fn string_arg(&self) -> String {
-        format!("{},{} -j", self.read.as_raw_fd(), self.write.as_raw_fd())
+        format!("{},{}", self.read.as_raw_fd(), self.write.as_raw_fd())
     }
 
     pub fn configure(&self, cmd: &mut Command) {


### PR DESCRIPTION
For some reason, it's only set on Unix, not Windows, but some versions
of GNU make will complain about "-jN forced in submake" when _no_ -j flag
is given at all, and disable the jobserver mode entirely.