### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,8 +226,8 @@ impl Client {
     /// any number of times.
     pub unsafe fn from_env() -> Option<Client> {
         let var = match env::var("CARGO_MAKEFLAGS")
-            .or(env::var("MAKEFLAGS"))
-            .or(env::var("MFLAGS"))
+            .or_else(|_| env::var("MAKEFLAGS"))
+            .or_else(|_| env::var("MFLAGS"))
         {
             Ok(s) => s,
             Err(_) => return None,
@@ -268,7 +268,7 @@ impl Client {
         let data = self.inner.acquire()?;
         Ok(Acquired {
             client: self.inner.clone(),
-            data: data,
+            data,
             disabled: false,
         })
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -26,7 +26,7 @@ impl Client {
         // I don't think the character written here matters, but I could be
         // wrong!
         for _ in 0..limit {
-            (&client.write).write(&[b'|'])?;
+            (&client.write).write_all(&[b'|'])?;
         }
         Ok(client)
     }
@@ -299,9 +299,7 @@ impl Helper {
 }
 
 fn is_valid_fd(fd: c_int) -> bool {
-    unsafe {
-        return libc::fcntl(fd, libc::F_GETFD) != -1;
-    }
+    unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
 }
 
 fn set_cloexec(fd: c_int, set: bool) -> io::Result<()> {

--- a/tests/client-of-myself.rs
+++ b/tests/client-of-myself.rs
@@ -1,5 +1,3 @@
-extern crate jobserver;
-
 use std::env;
 use std::io::prelude::*;
 use std::io::BufReader;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,10 +1,3 @@
-extern crate futures;
-extern crate jobserver;
-extern crate num_cpus;
-extern crate tempdir;
-extern crate tokio_core;
-extern crate tokio_process;
-
 use std::env;
 use std::fs::File;
 use std::io::Write;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -41,7 +41,7 @@ const TESTS: &[Test] = &[
     Test {
         name: "no j args",
         make_args: &[],
-        rule: &|me| format!("{}", me),
+        rule: &|me| me.to_string(),
         f: &|| {
             assert!(unsafe { Client::from_env().is_none() });
         },
@@ -124,7 +124,7 @@ fn main() {
 
     let me = t!(env::current_exe());
     let me = me.to_str().unwrap();
-    let filter = env::args().skip(1).next();
+    let filter = env::args().nth(1);
 
     let mut core = t!(Core::new());
 
@@ -146,7 +146,7 @@ all:
                 (test.rule)(me)
             );
             t!(t!(File::create(td.path().join("Makefile"))).write_all(makefile.as_bytes()));
-            let prog = env::var("MAKE").unwrap_or("make".to_string());
+            let prog = env::var("MAKE").unwrap_or_else(|_| "make".to_string());
             let mut cmd = Command::new(prog);
             cmd.args(test.make_args);
             cmd.current_dir(td.path());
@@ -174,7 +174,7 @@ all:
         Ok(())
     })));
 
-    if failures.len() == 0 {
+    if failures.is_empty() {
         println!("\ntest result: ok\n");
         return;
     }

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -20,7 +20,7 @@ fn helper_smoke() {
     drop(client.clone().into_helper_thread(|_| ()).unwrap());
     drop(client.clone().into_helper_thread(|_| ()).unwrap());
     drop(client.clone().into_helper_thread(|_| ()).unwrap());
-    drop(client.clone().into_helper_thread(|_| ()).unwrap());
+    drop(client.into_helper_thread(|_| ()).unwrap());
 }
 
 #[test]

--- a/tests/make-as-a-client.rs
+++ b/tests/make-as-a-client.rs
@@ -42,7 +42,7 @@ fn main() {
     let c = t!(Client::new(1));
     let td = TempDir::new("foo").unwrap();
 
-    let prog = env::var("MAKE").unwrap_or("make".to_string());
+    let prog = env::var("MAKE").unwrap_or_else(|_| "make".to_string());
 
     let me = t!(env::current_exe());
     let me = me.to_str().unwrap();

--- a/tests/make-as-a-client.rs
+++ b/tests/make-as-a-client.rs
@@ -1,6 +1,3 @@
-extern crate jobserver;
-extern crate tempdir;
-
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,6 +1,3 @@
-extern crate jobserver;
-extern crate tempdir;
-
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -61,7 +61,7 @@ fn make_as_a_single_thread_client() {
     let c = t!(Client::new(1));
     let td = TempDir::new("foo").unwrap();
 
-    let prog = env::var("MAKE").unwrap_or("make".to_string());
+    let prog = env::var("MAKE").unwrap_or_else(|_| "make".to_string());
     let mut cmd = Command::new(prog);
     cmd.current_dir(td.path());
 
@@ -115,7 +115,7 @@ fn make_as_a_multi_thread_client() {
     let c = t!(Client::new(1));
     let td = TempDir::new("foo").unwrap();
 
-    let prog = env::var("MAKE").unwrap_or("make".to_string());
+    let prog = env::var("MAKE").unwrap_or_else(|_| "make".to_string());
     let mut cmd = Command::new(prog);
     cmd.current_dir(td.path());
 


### PR DESCRIPTION
I also remove now unneeded `extern crate` statement since this crate uses 2018 edition.