### PR TITLE
Revert "Optionally increase the size of the pipe buffer"

### DIFF
--- a/tests/server.rs
+++ b/tests/server.rs
@@ -156,25 +156,3 @@ fn zero_client() {
         assert!(rx.try_recv().is_err());
     }
 }
-
-#[test]
-fn highly_concurrent() {
-    const N: usize = 10000;
-
-    let client = t!(Client::new(80));
-
-    let threads = (0..80)
-        .map(|_| {
-            let client = client.clone();
-            std::thread::spawn(move || {
-                for _ in 0..N {
-                    drop(client.acquire().unwrap());
-                }
-            })
-        })
-        .collect::<Vec<_>>();
-
-    for t in threads {
-        t.join().unwrap();
-    }
-}


### PR DESCRIPTION
This reverts commit 865b7e375a29afbc8283f14729d4663daa858a1e.

Lots of errors about "can't increase jobserver limits" are cropping up in https://github.com/rust-lang/rust/issues/88091, and nothing was really that broken before so let's back this out and figure out a better way to deal with this later.