### PR TITLE
Add `available` traits to find out how many client tokens are unused

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,19 @@ impl Client {
         })
     }
 
+    /// Returns amount of tokens in the read-side pipe.
+    ///
+    /// # Return value
+    ///
+    /// Number of bytes available to be read from the jobserver pipe
+    ///
+    /// # Errors
+    ///
+    /// Underlying errors from the ioctl will be passed up.
+    pub fn available(&self) -> io::Result<usize> {
+        self.inner.available()
+    }
+
     /// Configures a child process to have access to this client's jobserver as
     /// well.
     ///

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -59,6 +59,11 @@ impl Client {
         );
     }
 
+    pub fn available(&self) -> io::Result<usize> {
+        let lock = self.inner.count.lock().unwrap_or_else(|e| e.into_inner());
+        Ok(*lock)
+    }
+
     pub fn configure(&self, _cmd: &mut Command) {
         unreachable!();
     }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -34,6 +34,30 @@ fn server_multiple() {
 }
 
 #[test]
+fn server_available() {
+    let c = t!(Client::new(10));
+    assert_eq!(c.available().unwrap(), 10);
+    let a = c.acquire().unwrap();
+    assert_eq!(c.available().unwrap(), 9);
+    drop(a);
+    assert_eq!(c.available().unwrap(), 10);
+}
+
+#[test]
+fn server_none_available() {
+    let c = t!(Client::new(2));
+    assert_eq!(c.available().unwrap(), 2);
+    let a = c.acquire().unwrap();
+    assert_eq!(c.available().unwrap(), 1);
+    let b = c.acquire().unwrap();
+    assert_eq!(c.available().unwrap(), 0);
+    drop(a);
+    assert_eq!(c.available().unwrap(), 1);
+    drop(b);
+    assert_eq!(c.available().unwrap(), 2);
+}
+
+#[test]
 fn server_blocks() {
     let c = t!(Client::new(1));
     let a = c.acquire().unwrap();


### PR DESCRIPTION
Returns amount of tokens in the read-side pipe (number of jobs that could be started).
