### PR TITLE
Support `--jobserver-auth=fifo:PATH`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,28 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
+
     - run: cargo test
+
+    # Compile it from source (temporarily)
+    - name: Make GNU Make from source
+      if: ${{ !startsWith(matrix.os, 'windows') }}
+      env:
+        VERSION: "4.4.1"
+      shell: bash
+      run: |
+        wget -q "https://ftp.gnu.org/gnu/make/make-${VERSION}.tar.gz"
+        tar zxf "make-${VERSION}.tar.gz"
+        pushd "make-${VERSION}"
+        ./configure
+        make
+        popd
+        cp -rp "make-${VERSION}/make" .
+    - name: Test against GNU Make from source
+      if: ${{ !startsWith(matrix.os, 'windows') }}
+      shell: bash
+      run:
+        MAKE="${PWD}/make" cargo test
 
   rustfmt:
     name: Rustfmt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@
 //! The jobserver implementation can be found in [detail online][docs] but
 //! basically boils down to a cross-process semaphore. On Unix this is
 //! implemented with the `pipe` syscall and read/write ends of a pipe and on
-//! Windows this is implemented literally with IPC semaphores.
+//! Windows this is implemented literally with IPC semaphores. Starting from
+//! GNU `make` version 4.4, named pipe becomes the default way in communication
+//! on Unix. This crate also supports that feature in the sense of inheriting
+//! and forwarding the correct environment.
 //!
 //! The jobserver protocol in `make` also dictates when tokens are acquired to
 //! run child work, and clients using this crate should take care to implement


### PR DESCRIPTION
GNU `make` 4.4, released in October 2022[^1]. The jobserver defaults
to use named pipes (via `mkfifo(3)`) on supported platforms by
introducing a new IPC style `--jobserver-auth=fifo:PATH`, which `PATH`
is the path of fifo[^2].

This commit makes sure that the new style `--jobserver-auth=fifo:PATH`
can be forwarded to inherited processes correctly.

The support of creating a new client with named pipe will come as a
follow-up pull request.

[^1]: https://lists.gnu.org/archive/html/info-gnu/2022-10/msg00008.html
[^2]: https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html

