### PR TITLE
Fix IO safety in `unix.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,8 @@ harness = false
 [[test]]
 name = "helper"
 path = "tests/helper.rs"
+
+[[test]]
+name = "spawn-after-drop"
+path = "tests/spawn-after-drop.rs"
+harness = false

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -75,7 +75,7 @@ impl Client {
         Ok(*lock)
     }
 
-    pub fn configure(&self, _cmd: &mut Command) {
+    pub fn configure(self: &Arc<Self>, _cmd: &mut Command) {
         unreachable!();
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -214,7 +214,7 @@ impl Client {
         }
     }
 
-    pub fn configure(&self, _cmd: &mut Command) {
+    pub fn configure(self: &Arc<Self>, _cmd: &mut Command) {
         // nothing to do here, we gave the name of our semaphore to the
         // child above
     }

--- a/tests/spawn-after-drop.rs
+++ b/tests/spawn-after-drop.rs
@@ -1,0 +1,41 @@
+use std::{env, process::Command};
+
+use jobserver::{Client, FromEnvErrorKind};
+
+fn main() {
+    match env::args().skip(1).next().unwrap_or_default().as_str() {
+        "" => {
+            let me = env::current_exe().unwrap();
+            let mut cmd = Command::new(me);
+            let client = Client::new(1).unwrap();
+            client.configure(&mut cmd);
+            drop(client);
+            assert!(cmd.arg("from_env").status().unwrap().success());
+        }
+        "from_env" => {
+            let me = env::current_exe().unwrap();
+            let mut cmd = Command::new(me);
+            let client = unsafe {
+                match Client::from_env_ext(true).client {
+                    // Its ok for a dropped jobservers path to no longer exist (e.g. on Windows).
+                    Err(e) if matches!(e.kind(), FromEnvErrorKind::CannotOpenPath) => return,
+                    res => res.unwrap(),
+                }
+            };
+            client.configure(&mut cmd);
+            drop(client);
+            assert!(cmd.arg("use_it").status().unwrap().success());
+        }
+        "use_it" => {
+            let client = unsafe {
+                match Client::from_env_ext(true).client {
+                    // See above.
+                    Err(e) if matches!(e.kind(), FromEnvErrorKind::CannotOpenPath) => return,
+                    res => res.unwrap(),
+                }
+            };
+            client.acquire().unwrap();
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
As well as using `BorrowedFd` as opposed to `c_int` in more places, this PR fixes two related bugs:

- Unix `Client::configure()` wouldn't ensure the file descriptors passed to `Command::configure` remained valid until the command was actually spawned. This meant that if the `Client` was dropped before the `Command` was spawned, the `set_cloexec` call could end up hitting an unrelated file descriptor (which the spawned process would then treat as a jobserver).
- Unix `string_arg` uses the FDs from `ClientCreationArg::Fds` to put in the environment variables, but before this PR `Client::configure` would use the FDs from `self.read`/`self.write` instead. This would result in the wrong FDs getting passed to `set_cloexec`. This was basically harmless (apart from having the use-after-drop problem) as the only time the two sets of FDs differ is when the jobserver has been inherited from the environment, in which case the FDs are going to be not-CLOEXEC anyway.

I've also removed the `unsafe` from the definitions of `Client::mk` and `Client::from_fds` as they don't appear to have any safety requirements.