### PR TITLE
jobserver fd_check: Allow sockets.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,8 +32,12 @@ pub enum FromEnvErrorKind {
     /// is negative, which means it is disabled for this process
     /// ([GNU `make` manual: POSIX Jobserver Interaction](https://www.gnu.org/software/make/manual/make.html#POSIX-Jobserver)).
     NegativeFd,
-    /// File descriptor from the jobserver environment variable value is not a pipe.
+    /// Deprecated: File descriptor from is not a pipe, specifically.
+    #[deprecated(note = "Use `UnsupportedFdType` instead")]
     NotAPipe,
+    /// File descriptor from the jobserver environment variable value is not a
+    /// supported file type (pipe, socket or character device).
+    UnsupportedFdType,
     /// Jobserver inheritance is not supported on this platform.
     Unsupported,
 }
@@ -48,7 +52,7 @@ impl FromEnvError {
             FromEnvErrorInner::CannotOpenPath(..) => FromEnvErrorKind::CannotOpenPath,
             FromEnvErrorInner::CannotOpenFd(..) => FromEnvErrorKind::CannotOpenFd,
             FromEnvErrorInner::NegativeFd(..) => FromEnvErrorKind::NegativeFd,
-            FromEnvErrorInner::NotAPipe(..) => FromEnvErrorKind::NotAPipe,
+            FromEnvErrorInner::UnsupportedFdType(..) => FromEnvErrorKind::UnsupportedFdType,
             FromEnvErrorInner::Unsupported => FromEnvErrorKind::Unsupported,
         }
     }
@@ -63,8 +67,8 @@ impl std::fmt::Display for FromEnvError {
             FromEnvErrorInner::CannotOpenPath(s, err) => write!(f, "cannot open path or name {s} from the jobserver environment variable value: {err}"),
             FromEnvErrorInner::CannotOpenFd(fd, err) => write!(f, "cannot open file descriptor {fd} from the jobserver environment variable value: {err}"),
             FromEnvErrorInner::NegativeFd(fd) => write!(f, "file descriptor {fd} from the jobserver environment variable value is negative"),
-            FromEnvErrorInner::NotAPipe(fd, None) => write!(f, "file descriptor {fd} from the jobserver environment variable value is not a pipe"),
-            FromEnvErrorInner::NotAPipe(fd, Some(err)) => write!(f, "file descriptor {fd} from the jobserver environment variable value is not a pipe: {err}"),
+            FromEnvErrorInner::UnsupportedFdType(fd, None) => write!(f, "file descriptor {fd} from the jobserver environment variable value is not a supported file type (pipe, socket or character device)"),
+            FromEnvErrorInner::UnsupportedFdType(fd, Some(err)) => write!(f, "file descriptor {fd} from the jobserver environment variable value is not a supported file type (pipe, socket or character device): {err}"),
             FromEnvErrorInner::Unsupported => write!(f, "jobserver inheritance is not supported on this platform"),
         }
     }
@@ -73,9 +77,8 @@ impl std::error::Error for FromEnvError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self.inner {
             FromEnvErrorInner::CannotOpenPath(_, err) => Some(err),
-            FromEnvErrorInner::NotAPipe(_, Some(err)) | FromEnvErrorInner::CannotOpenFd(_, err) => {
-                Some(err)
-            }
+            FromEnvErrorInner::UnsupportedFdType(_, Some(err))
+            | FromEnvErrorInner::CannotOpenFd(_, err) => Some(err),
             _ => None,
         }
     }
@@ -90,6 +93,6 @@ pub(crate) enum FromEnvErrorInner {
     CannotOpenPath(String, std::io::Error),
     CannotOpenFd(RawFd, std::io::Error),
     NegativeFd(RawFd),
-    NotAPipe(RawFd, Option<std::io::Error>),
+    UnsupportedFdType(RawFd, Option<std::io::Error>),
     Unsupported,
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -165,10 +165,10 @@ impl Client {
         // then we'll have `MAKEFLAGS` env vars but won't actually have
         // access to the file descriptors.
         //
-        // `NotAPipe` is a worse error, return it if it's reported for any of the two fds.
+        // `UnsupportedFdType` is a worse error, return it if it's reported for any of the two fds.
         match (fd_check(read, check_pipe), fd_check(write, check_pipe)) {
-            (read_err @ Err(FromEnvErrorInner::NotAPipe(..)), _) => read_err?,
-            (_, write_err @ Err(FromEnvErrorInner::NotAPipe(..))) => write_err?,
+            (read_err @ Err(FromEnvErrorInner::UnsupportedFdType(..)), _) => read_err?,
+            (_, write_err @ Err(FromEnvErrorInner::UnsupportedFdType(..))) => write_err?,
             (read_err, write_err) => {
                 read_err?;
                 write_err?;
@@ -483,19 +483,32 @@ unsafe fn fd_check(fd: c_int, check_pipe: bool) -> Result<(), FromEnvErrorInner>
         if libc::fstat(fd, &mut stat) == -1 {
             let last_os_error = io::Error::last_os_error();
             fcntl_check(fd)?;
-            Err(FromEnvErrorInner::NotAPipe(fd, Some(last_os_error)))
+            Err(FromEnvErrorInner::UnsupportedFdType(
+                fd,
+                Some(last_os_error),
+            ))
         } else {
             // On android arm and i686 mode_t is u16 and st_mode is u32,
-            // this generates a type mismatch when S_IFIFO (declared as mode_t)
-            // is used in operations with st_mode, so we use this workaround
-            // to get the value of S_IFIFO with the same type of st_mode.
-            #[allow(unused_assignments)]
-            let mut s_ififo = stat.st_mode;
-            s_ififo = libc::S_IFIFO as _;
-            if stat.st_mode & s_ififo == s_ififo {
+            // this generates a type mismatch when the S_IF* constants (declared
+            // as mode_t) are used in operations with st_mode, so we use this
+            // workaround to get their value with the same type as st_mode.
+            let as_st_mode = |v| {
+                #[allow(unused_assignments)]
+                let mut t = stat.st_mode;
+                t = v as _;
+                t
+            };
+
+            let fmt = stat.st_mode & as_st_mode(libc::S_IFMT);
+            // Allow pipes (S_IFIFO), sockets (S_IFSOCK) and character devices
+            // (S_IFCHR)
+            if fmt == as_st_mode(libc::S_IFIFO)
+                || fmt == as_st_mode(libc::S_IFSOCK)
+                || fmt == as_st_mode(libc::S_IFCHR)
+            {
                 return Ok(());
             }
-            Err(FromEnvErrorInner::NotAPipe(fd, None))
+            Err(FromEnvErrorInner::UnsupportedFdType(fd, None))
         }
     } else {
         fcntl_check(fd)

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -569,7 +569,7 @@ extern "C" fn sigusr1_handler(
 mod test {
     use super::Client as ClientImp;
 
-    use crate::{test::run_named_fifo_try_acquire_tests, Client};
+    use crate::{test::run_named_fifo_try_acquire_tests, Client, FromEnvErrorInner};
 
     use std::{fs::File, io::Write, os::unix::io::AsRawFd, sync::Arc};
 
@@ -643,5 +643,53 @@ mod test {
 
         let (client, arg) = new_client_from_pipe();
         assert_eq!(client.inner.string_arg(), arg);
+    }
+
+    #[test]
+    fn test_fd_check_accepts_pipe() {
+        let (read, write) = nix::unistd::pipe().unwrap();
+        let read = File::from(read);
+        let write = File::from(write);
+        unsafe {
+            super::fd_check(read.as_raw_fd(), true).unwrap();
+            super::fd_check(write.as_raw_fd(), true).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_fd_check_accepts_socket() {
+        let (a, b) = std::os::unix::net::UnixStream::pair().unwrap();
+        unsafe {
+            super::fd_check(a.as_raw_fd(), true).unwrap();
+            super::fd_check(b.as_raw_fd(), true).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_fd_check_accepts_char_device() {
+        // `/dev/null` is a character device, and present ~everywhere?
+        let dev_null = File::open("/dev/null").unwrap();
+        unsafe {
+            super::fd_check(dev_null.as_raw_fd(), true).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_fd_check_rejects_regular_file() {
+        let file = tempfile::tempfile().unwrap();
+        let err = unsafe { super::fd_check(file.as_raw_fd(), true) }.unwrap_err();
+        assert!(
+            matches!(err, FromEnvErrorInner::UnsupportedFdType(_, None)),
+            "unexpected error: {err:?}",
+        );
+    }
+
+    #[test]
+    fn test_fd_check_skips_type_check_when_check_pipe_false() {
+        // `fd_check=false` only verifies the fd is open.
+        let file = tempfile::tempfile().unwrap();
+        unsafe {
+            super::fd_check(file.as_raw_fd(), false).unwrap();
+        }
     }
 }


### PR DESCRIPTION
I agree with the creator of issue #6 that jobserver fds should be allowed to be sockets as well as pipes. A project I'm working on uses a jobserver implemented over Unix domain sockets.